### PR TITLE
Implement multilingual support

### DIFF
--- a/lib/url-builder.js
+++ b/lib/url-builder.js
@@ -37,6 +37,10 @@ function urlBuilder(params) {
     builtUrl += '&';
   }
 
+  if (params.language) {
+    builtUrl += 'language=' + params.language + '&';
+  }
+
   builtUrl += 'callback=' + params.callback;
 
   return builtUrl;

--- a/src/google-maps-api-loader.js
+++ b/src/google-maps-api-loader.js
@@ -15,7 +15,8 @@ function loadAutoCompleteAPI(params) {
     libraries: params.libraries || [],
     callback: 'googleMapsAutoCompleteAPILoad',
     apiKey: params.apiKey,
-    client: params.client
+    client: params.client,
+    language: params.language
   });
 
   document.querySelector('head').appendChild(script);

--- a/test/google-maps-api-loader.spec.js
+++ b/test/google-maps-api-loader.spec.js
@@ -12,13 +12,14 @@ var urlBuilder = require('../lib/url-builder');
 
 describe('urlBuilder', function() {
   it('Should create URLs with all the properties', function() {
-    var result = 'first-base?key=abc123&client=def456&libraries=places,moreplaces&callback=heyyyy';
+    var result = 'first-base?key=abc123&client=def456&libraries=places,moreplaces&language=en&callback=heyyyy';
 
     var url = urlBuilder({
       base: 'first-base',
       libraries: ['places','moreplaces'],
       apiKey: 'abc123',
       client: 'def456',
+      language: 'en',
       callback: 'heyyyy'
     });
     expect(url).to.equal(result);

--- a/test/url-builder.spec.js
+++ b/test/url-builder.spec.js
@@ -13,6 +13,7 @@ describe('urlBuilder', function() {
     builtUrl = urlBuilder({
       base: 'https://maps.googleapis.com/maps/api/js',
       libraries: ['places', 'geometry'],
+			language: 'en',
       callback: 'apiLoaded'
     });
   });
@@ -26,6 +27,7 @@ describe('urlBuilder', function() {
 
     expect(paramSection).to.be.a('string');
     expect(paramSection).to.have.string('libraries=places,geometry');
+    expect(paramSection).to.have.string('&language=en');
     expect(paramSection).to.have.string('&callback=apiLoaded');
   });
 });


### PR DESCRIPTION
This PR adds support for language parameters which determines the locale of the strings returned by google services such as geocoder.

This feature is officially documented here:  https://developers.google.com/maps/documentation/javascript/localization