### PR TITLE
Implementing version control support

### DIFF
--- a/lib/url-builder.js
+++ b/lib/url-builder.js
@@ -41,6 +41,10 @@ function urlBuilder(params) {
     builtUrl += 'language=' + params.language + '&';
   }
 
+  if (params.version) {
+    builtUrl += 'v=' + params.version + '&';
+  }
+
   builtUrl += 'callback=' + params.callback;
 
   return builtUrl;

--- a/src/google-maps-api-loader.js
+++ b/src/google-maps-api-loader.js
@@ -16,7 +16,8 @@ function loadAutoCompleteAPI(params) {
     callback: 'googleMapsAutoCompleteAPILoad',
     apiKey: params.apiKey,
     client: params.client,
-    language: params.language
+    language: params.language,
+    version: params.version
   });
 
   document.querySelector('head').appendChild(script);

--- a/test/google-maps-api-loader.spec.js
+++ b/test/google-maps-api-loader.spec.js
@@ -12,7 +12,7 @@ var urlBuilder = require('../lib/url-builder');
 
 describe('urlBuilder', function() {
   it('Should create URLs with all the properties', function() {
-    var result = 'first-base?key=abc123&client=def456&libraries=places,moreplaces&language=en&callback=heyyyy';
+    var result = 'first-base?key=abc123&client=def456&libraries=places,moreplaces&language=en&v=3&callback=heyyyy';
 
     var url = urlBuilder({
       base: 'first-base',
@@ -20,6 +20,7 @@ describe('urlBuilder', function() {
       apiKey: 'abc123',
       client: 'def456',
       language: 'en',
+      version: 3,
       callback: 'heyyyy'
     });
     expect(url).to.equal(result);

--- a/test/url-builder.spec.js
+++ b/test/url-builder.spec.js
@@ -13,7 +13,8 @@ describe('urlBuilder', function() {
     builtUrl = urlBuilder({
       base: 'https://maps.googleapis.com/maps/api/js',
       libraries: ['places', 'geometry'],
-			language: 'en',
+      language: 'en',
+      version: 3,
       callback: 'apiLoaded'
     });
   });
@@ -28,6 +29,7 @@ describe('urlBuilder', function() {
     expect(paramSection).to.be.a('string');
     expect(paramSection).to.have.string('libraries=places,geometry');
     expect(paramSection).to.have.string('&language=en');
+    expect(paramSection).to.have.string('&v=3');
     expect(paramSection).to.have.string('&callback=apiLoaded');
   });
 });


### PR DESCRIPTION
This adds support to use a specific version of the Google Maps API to prevent possible implementations to break due to new changes in the API.

See more here:
https://developers.google.com/maps/documentation/javascript/versions