### PR TITLE
add cn type

### DIFF
--- a/src/google-maps-api-loader.js
+++ b/src/google-maps-api-loader.js
@@ -10,8 +10,10 @@ function loadAutoCompleteAPI(params) {
 
   script.type = 'text/javascript';
 
+  var baseUrl = (typeof params.loadCn == 'boolean' && params.loadCn) ? 'http://maps.google.cn/' : 'https://maps.googleapis.com/';
+
   script.src = urlBuilder({
-    base: 'https://maps.googleapis.com/maps/api/js',
+    base: baseUrl + 'maps/api/js',
     libraries: params.libraries || [],
     callback: 'googleMapsAutoCompleteAPILoad',
     apiKey: params.apiKey,


### PR DESCRIPTION
The URL of the API provided is different in China.
Therefore, I added an option on China or not.

https://developers.google.com/maps/documentation/javascript/localization#GoogleMapsChina